### PR TITLE
Add the '-split' flag to bedgraphs in single end analysis

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -931,12 +931,14 @@ process bedgraphs {
     """    
     genomeCoverageBed \
         -bg \
+        -split \
         -strand + \
         -g ${chrom_sizes} \
         -ibam ${bam_file} \
         > ${name}.pos.bedGraph
     genomeCoverageBed \
         -bg \
+        -split \
         -strand - \
         -g ${chrom_sizes} \
         -ibam ${bam_file} \


### PR DESCRIPTION
This fixes an existing bug where the final produced bedGraph files did
not do splitting at exons, causing the final IGV tracks to look
incorrect.